### PR TITLE
 aws관련 클라우드들 SDK2.x 버전으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	//AWS s3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws-messaging'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws-parameter-store-config'
+	implementation(platform("software.amazon.awssdk:bom:2.27.5"))
+	implementation("software.amazon.awssdk:s3")
+
 	//valid
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
-
 tasks.named('test') {
 	useJUnitPlatform()
 }


### PR DESCRIPTION
# 관련 이슈
- [x] #25

# 해결 항목
- [x] SDK 2.x버전으로 변경
 
# 해결 방법

```markdown
implementation(platform("software.amazon.awssdk:bom:2.27.5"))
implementation("software.amazon.awssdk:s3")
```
close #25 